### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "recaptchaenterprise",
     "name_pretty": "reCAPTCHA Enterprise",
     "product_documentation": "https://cloud.google.com/recaptcha-enterprise",
-    "client_documentation": "https://googleapis.dev/python/recaptchaenterprise/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/recaptchaenterprise/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ and automated account creation.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-recaptcha-enterprise.svg
    :target: https://pypi.org/project/google-cloud-recaptcha-enterprise/
 .. _reCAPTCHA Enterprise: https://cloud.google.com/recaptcha-enterprise/
-.. _Client Library Documentation: https://googleapis.dev/python/recaptchaenterprise/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/recaptchaenterprise/latest
 .. _Product Documentation:  https://cloud.google.com/recaptcha-enterprise/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.